### PR TITLE
Add in a `.distignore` file

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,21 @@
+# Directories to ignore
+/.git
+/.github
+/.wordpress-org
+/node_modules
+/tests
+/vendor
+
+# Files to ignore
+/.*
+/CODE_OF_CONDUCT.md
+/composer.json
+/composer.lock
+/LICENSE.md
+/package-lock.json
+/package.json
+/phpcs-compat.xml.dist
+/phpcs.xml.dist
+/phpunit.xml.dist
+/README.md
+/webpack.config.js


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

The Action we use to deploy to WordPress.org supports having either a `.distignore` file or a `.gitattributes` file. Right now we only have the latter and the issue here is we have a `build` directory that we exclude from the git repo but we want that in our final release. That isn't possible with a `.gitattributes` file, only with a `.distignore` file, so adding that here so we can push out another release with the proper `build` directory in place.

### Steps to test the changes in this Pull Request:

n/a

### Changelog entry

> Fix - Ensure the final release asset includes the `build` directory.