### PR TITLE
Update displayname to `GoCardless for WooCommerce`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WooCommerce GoCardless Gateway
+# GoCardless for WooCommerce
 
 > Extends WooCommerce with a GoCardless gateway. A GoCardless merchant account is required.
 
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This is a feature plugin for accepting payments via [GoCardless](https://gocardless.com/). It requires [WooCommerce](https://wordpress.org/plugins/woocommerce/) to be installed before the WooCommerce GoCardless Gateway can be activated.
+This is a feature plugin for accepting payments via [GoCardless](https://gocardless.com/). It requires [WooCommerce](https://wordpress.org/plugins/woocommerce/) to be installed before GoCardless for WooCommerce can be activated.
 
 ## Compatibility
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-*** WooCommerce GoCardless Gateway Changelog ***
+*** GoCardless for WooCommerce Changelog ***
 
 2025-02-12 - version 2.9.1
 * Fix - Ensure the final release asset includes the `build` directory.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce-gateway-gocardless",
 	"version": "2.9.1",
-	"description": "WooCommerce GoCardless Gateway",
+	"description": "GoCardless for WooCommerce",
 	"homepage": "https://woocommerce.com/products/gocardless/",
 	"license": "GPL-3.0-or-later",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WooCommerce GoCardless Gateway ===
+=== GoCardless for WooCommerce ===
 Contributors: gocardless, woocommerce, automattic
 Tags:         gocardless, woocommerce, direct debit, instant bank pay
 Tested up to: 6.7
@@ -10,7 +10,7 @@ Extends WooCommerce with a GoCardless gateway. A GoCardless merchant account is 
 
 == Description ==
 
-This is a feature plugin for accepting payments via [GoCardless](https://gocardless.com/).  It requires [WooCommerce](https://wordpress.org/plugins/woocommerce/) to be installed before the WooCommerce GoCardless Gateway can be activated.
+This is a feature plugin for accepting payments via [GoCardless](https://gocardless.com/).  It requires [WooCommerce](https://wordpress.org/plugins/woocommerce/) to be installed before GoCardless for WooCommerce can be activated.
 
 = Compatibility =
 

--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Initializing WooCommerce GoCardless Gateway E2E"
+echo "Initializing GoCardless for WooCommerce E2E"
 
 # Enable pretty permalinks.
 wp-env run tests-wordpress chmod -c ugo+w /var/www/html

--- a/tests/e2e/specs/admin.spec.js
+++ b/tests/e2e/specs/admin.spec.js
@@ -35,7 +35,7 @@ test.describe('Admin Tests', () => {
 		// Addon is active by default in the test environment, so we need to validate that it is activated.
 		await expect(
 			page.getByRole('link', {
-				name: 'Deactivate WooCommerce GoCardless Gateway',
+				name: 'Deactivate GoCardless for WooCommerce',
 				exact: true,
 			})
 		).toBeVisible();

--- a/tests/e2e/test-plugins/e2e-test-plugin/e2e-test-plugin.php
+++ b/tests/e2e/test-plugins/e2e-test-plugin/e2e-test-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin name: WooCommerce WooCommerce GoCardless Gateway Test plugin
+ * Plugin name: GoCardless for WooCommerce Test plugin
  */
 
 // Remove the https from the API request URL

--- a/woocommerce-gateway-gocardless.php
+++ b/woocommerce-gateway-gocardless.php
@@ -1,6 +1,6 @@
 <?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName -- Main plugin file
 /**
- * Plugin Name:          WooCommerce GoCardless Gateway
+ * Plugin Name:          GoCardless for WooCommerce
  * Plugin URI:           https://www.woocommerce.com/products/gocardless/
  * Description:          Extends both WooCommerce and WooCommerce Subscriptions with the GoCardless Payment Gateway. A GoCardless merchant account is required.
  * Version:              2.9.1


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR updates the plugin's displayname from "WooCommerce GoCardless Gateway" to "GoCardless for WooCommerce" to match standards now that this is no longer a Woo-owned extension and thus the "WooCommerce" reference moving to the end of the name.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

n/a

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

n/a