### PR TITLE
Ensure the subscription is cancelled immediately when the payment is cancelled.

### DIFF
--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -1887,6 +1887,16 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				break;
 		}
 
+		/*
+		* Skip the Pending Cancel status for subscriptions.
+		*
+		* Subscriptions orders are updated to the "processing" status without confirmed payment.
+		* If a payment is cancelled, the subscription must be cancelled immediately.
+		*
+		* @see https://github.com/woocommerce/woocommerce-gateway-gocardless-private/issues/75
+		*/
+		add_filter( 'woocommerce_subscription_use_pending_cancel', '__return_false' );
+
 		if ( ! empty( $new_status ) ) {
 			$note = ! empty( $event['details']['description'] ) ? $event['details']['description'] : '';
 			$order->update_status( $new_status, $note );
@@ -1919,6 +1929,9 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				$subscription->cancel_order( $note );
 			}
 		}
+
+		// Remove the filter added above.
+		remove_filter( 'woocommerce_subscription_use_pending_cancel', '__return_false' );
 
 		return true;
 	}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:
As reported in #43, currently, when a mandate is cancelled, the pending payment also gets cancelled. The extension handles the webhook for this payment cancellation, and the order status is updated to "cancelled", but the subscription status remains "Pending cancellation" for the duration of the subscription interval.

This occurs because we mark the order status as "processing" for subscription orders (there has been discussion on this, please check [this](https://github.com/woocommerce/woocommerce-gateway-gocardless-private/issues/75) for more context). Marking the order as "processing" activates the subscription, and when the order status is updated to "cancelled," the subscription status changes to "Pending cancellation" to allow customers to continue accessing subscription benefits until the next payment is due.

This PR fixes this issue and utilizes the subscriptions' filter to skip the "Pending cancellation" status and cancel the subscription immediately.

Closes #43 

### Steps to test the changes in this Pull Request:
1. Create a new subscription product and sign up for it using the GoCardless payment gateway.  
2. Go to the GoCardless dashboard and cancel the mandate attached to that subscription.  
3. Verify that the subscription is cancelled immediately instead of entering the "Pending cancellation" status.

### Changelog entry
> Fix -  Ensure that the subscription is cancelled immediately when the payment is cancelled.