### PR TITLE
Run E2E tests on the zip generated by the generate-zip workflow and ensure it runs on each PR.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - trunk
+      - smoke-testing
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,6 +62,8 @@ jobs:
           unzip -o woocommerce-pre-orders.zip
           unzip -o woocommerce-subscriptions.zip
           cd ..
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
 
       - name: Set the plugin and core version config
         run: ./tests/e2e/bin/set-core-version.js --core=${{ env.CORE_VERSION }} --plugin=./${{ github.event.repository.name }}
@@ -75,7 +77,6 @@ jobs:
         env:
           GOCARDLESS_EMAIL: ${{secrets.GOCARDLESS_EMAIL}}
           GOCARDLESS_PASSWORD: ${{secrets.GOCARDLESS_PASSWORD}}
-          GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
 
       - name: Update Success Label
         if: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,18 +11,29 @@ on:
       - develop
 
 jobs:
+  build:
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
+
   e2e:
-    if: "${{ ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'needs: e2e testing') ) ||  github.event_name == 'push' }}"
+    needs: build
     name: E2E Test
     runs-on: ubuntu-latest
     env:
-      GOCARDLESS_EMAIL: ${{secrets.GOCARDLESS_EMAIL}}
-      GOCARDLESS_PASSWORD: ${{secrets.GOCARDLESS_PASSWORD}}
-      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
+      CORE_VERSION: ${{ contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') && 'WordPress/WordPress#master' || 'latest' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: Download build zip
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
+        with:
+          name: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: ${{ github.event.repository.name }}
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
@@ -40,9 +51,6 @@ jobs:
       - name: Node install
         run: npm ci
 
-      - name: Build
-        run: npm run build
-
       - name: Install Playwright Browsers
         run: npx playwright install chromium
 
@@ -55,18 +63,19 @@ jobs:
           unzip -o woocommerce-subscriptions.zip
           cd ..
 
-      - name: Set the core version
-        if: "${{ contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') }}"
-        id: run-rc-test
-        run: ./tests/e2e/bin/set-core-version.js WordPress/WordPress#master
+      - name: Set the plugin and core version config
+        run: ./tests/e2e/bin/set-core-version.js --core=${{ env.CORE_VERSION }} --plugin=./${{ github.event.repository.name }}
 
       - name: Setup WP environment
         run: npm run env:start
 
       - name: Run E2E Foundational Test
         id: gocardless_e2e_tests
-        if: ${{ github.event_name == 'pull_request' }}
-        run: npm run test:e2e-foundational
+        run: npm run test:e2e
+        env:
+          GOCARDLESS_EMAIL: ${{secrets.GOCARDLESS_EMAIL}}
+          GOCARDLESS_PASSWORD: ${{secrets.GOCARDLESS_PASSWORD}}
+          GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
 
       - name: Update Success Label
         if: |
@@ -109,10 +118,6 @@ jobs:
               repo: context.repo.repo,
               labels: ['status: e2e tests failing']
             })
-
-      - name: Run E2E Smoke Test
-        if: ${{ github.event_name == 'push' }}
-        run: npm run test:e2e
 
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
     name: E2E Test
     runs-on: ubuntu-latest
     env:
-      CORE_VERSION: ${{ contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') && 'WordPress/WordPress#master' || 'latest' }}
+      CORE_VERSION: "${{(contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') && 'WordPress/WordPress#master') || 'latest'}}"
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
         with:
           name: ${{ github.event.repository.name }}
-          path: ${{ github.event.repository.name }}
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/tests/e2e/bin/set-core-version.js
+++ b/tests/e2e/bin/set-core-version.js
@@ -1,34 +1,48 @@
 #!/usr/bin/env node
 
-const fs = require( 'fs' );
-const { exit } = require( 'process' );
+const fs = require('fs');
 
-const path = `${ process.cwd() }/.wp-env.override.json`;
+const path = `${process.cwd()}/.wp-env.json`;
 
-// eslint-disable-next-line import/no-dynamic-require
-const config = fs.existsSync( path ) ? require( path ) : {};
+let config = fs.existsSync(path)
+	? require(path)
+	: {
+			plugins: [
+				'https://downloads.wordpress.org/plugin/woocommerce.zip',
+				'https://downloads.wordpress.org/plugin/email-log.zip',
+				'.',
+			],
+		};
 
-const args = process.argv.slice( 2 );
-
-if ( args.length === 0 ) exit( 0 );
-
-if ( args[ 0 ] === 'latest' ) {
-	if ( fs.existsSync( path ) ) {
-		fs.unlinkSync( path );
+const args = {};
+process.argv.slice(2, process.argv.length).forEach((arg) => {
+	if (arg.slice(0, 2) === '--') {
+		const param = arg.split('=');
+		const paramName = param[0].slice(2, param[0].length);
+		const paramValue = param.length > 1 ? param[1] : true;
+		if (paramName === 'plugin') {
+			// Replace "." with paramValue in the plugins array
+            config.plugins = config.plugins.map((plugin) =>
+                plugin === '.' ? paramValue : plugin
+            );
+		} else {
+			args[paramName] = paramValue;
+		}
 	}
-	exit( 0 );
+});
+
+if ('latest' === args.core) {
+	delete args.core;
+	delete config.core;
 }
 
-config.core = args[ 0 ];
-
-// eslint-disable-next-line no-useless-escape
-if ( ! config.core.match( /^WordPress\/WordPress\#/ ) ) {
-	config.core = `WordPress/WordPress#${ config.core }`;
-}
+config = {
+	...config,
+	...args,
+};
 
 try {
-	fs.writeFileSync( path, JSON.stringify( config ) );
-} catch ( err ) {
-	// eslint-disable-next-line no-console
-	console.error( err );
+	fs.writeFileSync(path, JSON.stringify(config));
+} catch (err) {
+	console.error(err);
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR updates the E2E GitHub Action workflow to run by default on every pull request (no need to add a label manually). It also modifies the workflow to execute E2E tests on the build zip generated by the `generate-zip` workflow.

### Steps to test the changes in this Pull Request:
Verify that the E2E workflow runs on this PR and works as expected.

### Changelog entry
> Dev - Run E2E tests on the zip generated by the `generate-zip` workflow and ensure it runs on every pull request by default.
