### PR TITLE
Fix "Translation loading for the woocommerce-gateway-gocardless domain was triggered too early" error on WP 6.7

### DIFF
--- a/includes/class-wc-gocardless-privacy.php
+++ b/includes/class-wc-gocardless-privacy.php
@@ -22,7 +22,17 @@ class WC_GoCardless_Privacy extends WC_Abstract_Privacy {
 	 * Constructor
 	 */
 	public function __construct() {
-		parent::__construct( __( 'Direct Debit (GoCardless)', 'woocommerce-gateway-gocardless' ) );
+		parent::__construct();
+
+		// Initialize data exporters and erasers.
+		add_action( 'init', array( $this, 'register_erasers_exporters' ) );
+	}
+
+	/**
+	 * Initial registration of privacy erasers and exporters.
+	 */
+	public function register_erasers_exporters() {
+		$this->name = __( 'Direct Debit (GoCardless)', 'woocommerce-gateway-gocardless' );
 
 		$this->add_exporter( 'woocommerce-gateway-gocardless-order-data', __( 'WooCommerce GoCardless Order Data', 'woocommerce-gateway-gocardless' ), array( $this, 'order_data_exporter' ) );
 

--- a/woocommerce-gateway-gocardless.php
+++ b/woocommerce-gateway-gocardless.php
@@ -85,6 +85,7 @@ class WC_GoCardless {
 		add_action( 'plugins_loaded', array( $this, 'init' ), 11 );
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'register_gateway' ) );
 		add_action( 'admin_notices', array( $this, 'environment_check' ) );
+		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 
 		$this->plugin_path = untrailingslashit( plugin_dir_path( __FILE__ ) );
 		$this->plugin_url  = untrailingslashit( plugins_url( '/', __FILE__ ) );
@@ -237,10 +238,15 @@ class WC_GoCardless {
 		$reports_handler = new WC_GoCardless_Reports();
 		$reports_handler->init();
 
+		add_action( 'init', array( $this, 'init_order_admin' ) );
+	}
+
+	/**
+	 * Load plugin text domain for translation.
+	 */
+	public function load_plugin_textdomain() {
 		// Localisation.
 		load_plugin_textdomain( 'woocommerce-gateway-gocardless', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
-
-		add_action( 'init', array( $this, 'init_order_admin' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
In WordPress 6.7, they [changed the way translations are loaded](https://core.trac.wordpress.org/changeset/59127) which affects how and when translation strings should be triggered. With this change, any `__()` code called before the `after_setup_theme` is considered "too early" and will need to be updated to happen on a later hook. This PR updates code to fix these too-early translation notices.

Closes #52 

### Steps to test the changes in this Pull Request:
1. Ensure `define( 'WP_DEBUG', true );` is set in `wp-config.php`.  
2. Update to the latest version of WordPress 6.7 or 6.8.  
3. Navigate to your Edit User Profile page and update the language to something other than "English."  
4. Ensure there are no notices on the WordPress admin screen.

### Changelog entry
> Fix - Resolved "translation loading was triggered too early" issue in WordPress 6.7.