### PR TITLE
Respond with an error to the GoCardless webhook call if the scheduling action fails.

### DIFF
--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -1619,17 +1619,28 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				throw new Exception( esc_html__( 'Missing events in payload.', 'woocommerce-gateway-gocardless' ) );
 			}
 
+			wc_gocardless()->log( sprintf( '%s - Handling webhook. Payload: %s', __METHOD__, print_r( $payload, true ) ) );
+
 			$args = array( $payload );
 
 			// Process the webhook payload asynchronously.
-			WC()->queue()->schedule_single(
+			$action_id = WC()->queue()->schedule_single(
 				WC()->call_function( 'time' ) + 1,
 				'woocommerce_gocardless_process_webhook_payload_async',
 				$args,
 				'woocommerce-gocardless-webhook'
 			);
 
+			// If the action is not scheduled, return error to GoCardless, to get a retry.
+			if ( empty( $action_id ) ) {
+				wc_gocardless()->log( sprintf( '%s - Failed to schedule action to process webhook.', __METHOD__ ) );
+				header( 'HTTP/1.1 500 Internal Server Error' );
+				throw new Exception( esc_html__( 'Failed to schedule action to process webhook.', 'woocommerce-gateway-gocardless' ) );
+			}
+
+			wc_gocardless()->log( sprintf( '%s - Action scheduled with ID %d, to process webhook.', __METHOD__, $action_id ) );
 		} catch ( Exception $e ) {
+			wc_gocardless()->log( sprintf( '%s - Error when handling webhook: %s', __METHOD__, $e->getMessage() ) );
 			wp_send_json_error( array( 'message' => $e->getMessage() ) );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
The plugin currently handles webhook events by scheduling an Action Scheduler task so the webhook payload can be processed asynchronously, allowing us to respond to GoCardless quickly. However, as reported in #31, in some environments, if scheduling the action fails, the plugin still responds to GoCardless with a success status. This results in the WooCommerce order status not being updated.

This PR updates the webhook handling to return an error (500 Internal Server Error) if action scheduling fails. By receiving this error, GoCardless will attempt to resend the webhook up to 8 times at increasing time intervals. In addition to responding with an error, the PR also logs the webhook payload to help troubleshoot issues.

Closes #31 

### Steps to test the changes in this Pull Request:
This issue is not reproducible. So, verifying that webhook handling works properly and that the payload data is logged correctly should be sufficient.

### Changelog entry
> Add - Respond with an error to the GoCardless webhook call if the scheduling action fails.