### PR TITLE
Run E2E tests on the zip generated by "Build release zip" action.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@enhancement/33
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
 
   e2e:
     needs: build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@enhancement/33
 
   e2e:
     needs: build
@@ -30,6 +30,7 @@ jobs:
         uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
         with:
           name: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -35,11 +35,8 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci --no-optional
 
-      - name: Generate ZIP file
-        run: npm run build && rm -rf ./woocommerce-gateway-gocardless && unzip woocommerce-gateway-gocardless.zip -d ./woocommerce-gateway-gocardless
+      - name: Build plugin
+        run: npm run build
 
-      - name: Use the Upload Artifact GitHub Action
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
-        with:
-          name: woocommerce-gateway-gocardless
-          path: woocommerce-gateway-gocardless/
+      - name: Generate ZIP file
+        uses: 10up/action-wordpress-plugin-build-zip@b9e621e1261ccf51592b6f3943e4dc4518fca0d1 # v1.0.2

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -1,4 +1,4 @@
-name: Generate ZIP file
+name: Build release zip
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   generate-zip-file:
-    name: Generate ZIP file
+    name: Build release zip
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR updates the `generate-zip` workflow file to use the `10up/action-wordpress-plugin-build-zip` action. This action generates the ZIP file in the same way as the [WordPress.org Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy). Using this action provides peace of mind, knowing that we’ve tested exactly what will be deployed.


Closes #33

### Steps to test the changes in this Pull Request:
Make sure that E2E tests GitHub action on this PR is passing.

### Changelog entry

> Dev - Run E2E tests on the zip generated by "Build release zip" action.