### PR TITLE
Add a notice indicating that GoCardless is connected in sandbox mode.

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -39,3 +39,14 @@
     color: #d63638;
     margin-top: 6px;
 }
+
+.wcgc-sandbox-mode-notice {
+    margin-top: 12px;
+    align-items: center;
+    background-color: #fff2d7;
+    color: #4d3716;
+    display: flex;
+    font-size: 13px;
+    padding: 12px;
+    width: max-content;
+}

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -230,6 +230,20 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 
 				<?php if ( ! empty( $access_token ) ) : ?>
 					<span class="gocardless-connected"><span style="color: #00a32a">&#9679;</span>&nbsp;<?php esc_html_e( 'Connected', 'woocommerce-gateway-gocardless' ); ?></span>
+
+					<?php if ( $this->testmode ) : ?>
+						<div class="wcgc-sandbox-mode-notice">
+							<span>
+								<?php
+								printf(
+									'<strong>%1$s</strong> %2$s',
+									esc_html__( 'GoCardless is connected in sandbox mode.', 'woocommerce-gateway-gocardless' ),
+									esc_html__( 'You need to connect a live GoCardless account before you can accept real bank payments.', 'woocommerce-gateway-gocardless' )
+								);
+								?>
+							</span>
+						</div>
+					<?php endif; ?>
 				<?php endif; ?>
 
 				<?php if ( empty( $access_token ) ) : ?>


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #6, there is currently no visual difference on the GoCardless Settings page when a live account is connected versus when a sandbox account is connected. This can cause confusion for users who may be unsure whether they're connected to a live or sandbox GoCardless account.

This PR adds a notice below the disconnect button indicating that a sandbox account is connected, if the merchant is using sandbox mode, to help clarify it.

![image](https://github.com/user-attachments/assets/14f09168-2818-4e1c-869d-a1f896e24572)


Closes #6 

### Steps to test the changes in this Pull Request:
1. Connect to a GoCardless sandbox account.
2. Verify that a notice appears indicating you are connected to a GoCardless sandbox account.
3. Disconnect and re-connect the account to a live/production account.
4. Verify that the notice no longer appears.

### Changelog entry
> Add -  A notice indicating that GoCardless is connected in sandbox mode, if the merchant is connected to a sandbox account.