### PR TITLE
Cancel 'pending_submission' payment and disable payment retries upon subscription cancellation.

### DIFF
--- a/includes/class-wc-gocardless-api.php
+++ b/includes/class-wc-gocardless-api.php
@@ -402,6 +402,23 @@ class WC_GoCardless_API {
 	}
 
 	/**
+	 * Update payment.
+	 *
+	 * @param string $payment_id Payment ID.
+	 * @param array  $params     Parameters to update payment.
+	 *
+	 * @return array|WP_Error
+	 */
+	public static function update_payment( $payment_id, $params = array() ) {
+		$args = array(
+			'method' => 'PUT',
+			'body'   => wp_json_encode( array( 'payments' => $params ) ),
+		);
+
+		return self::_request( 'payments/' . $payment_id, $args );
+	}
+
+	/**
 	 * Get a single payment from given payment_id.
 	 *
 	 * @param string $payment_id Payment ID.
@@ -417,7 +434,7 @@ class WC_GoCardless_API {
 	 *
 	 * @param string $payment_id Payment ID.
 	 *
-	 * @return array
+	 * @return array|WP_Error
 	 */
 	public static function cancel_payment( $payment_id ) {
 		$args = array(

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -29,6 +29,10 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			// Allow store managers to manually set GoCardless as the payment method on a subscription.
 			add_filter( 'woocommerce_subscription_payment_meta', array( $this, 'add_subscription_payment_meta' ), 10, 2 );
 			add_action( 'woocommerce_subscription_validate_payment_meta', array( $this, 'validate_subscription_payment_meta' ), 10, 2 );
+
+			// Cancel in-progress payment on subscription cancellation.
+			add_action( 'woocommerce_subscription_pending-cancel_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
+			add_action( 'woocommerce_subscription_cancelled_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
 		}
 
 		if ( class_exists( 'WC_Pre_Orders_Order' ) ) {
@@ -320,6 +324,65 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 
 			if ( 0 !== strpos( $payment_meta['post_meta']['_gocardless_mandate_id']['value'], 'MD' ) ) {
 				throw new Exception( esc_html__( 'Invalid GoCardless Mandate ID. A valid "GoCardless Mandate ID" must begin with "MD".', 'woocommerce-gateway-gocardless' ) );
+			}
+		}
+	}
+
+	/**
+	 * Cancel the order payment on subscription cancellation.
+	 *
+	 * If the payment is pending submission, we can cancel it.
+	 * Otherwise, update the retry_if_possible to false to avoid the payment being retried (except for paid_out and cancelled payment states).
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Subscription $subscription Subscription object.
+	 */
+	public function maybe_cancel_subscription_payment( $subscription ) {
+		if ( ! $subscription ) {
+			return;
+		}
+		wc_gocardless()->log( sprintf( '%s - Subscription cancelled/Pending cancellation, checking if payment should be cancelled', __METHOD__ ) );
+
+		$last_order = $subscription->get_last_order( 'all' );
+		if ( ! $last_order ) {
+			return;
+		}
+
+		$payment_id = $this->get_order_resource( $last_order->get_id(), 'payment', 'id' );
+		$payment    = WC_GoCardless_API::get_payment( $payment_id );
+		if ( is_wp_error( $payment ) || empty( $payment['payments'] ) ) {
+			wc_gocardless()->log( sprintf( '%s - Failed to retrieve payment.', __METHOD__ ) );
+			return;
+		}
+
+		$gocardless_status = $payment['payments']['status'] ?? '';
+		wc_gocardless()->log( sprintf( '%s - GoCardless payment status: %s', __METHOD__, $gocardless_status ) );
+
+		// If the payment is pending submission, we can cancel it.
+		if ( 'pending_submission' === $gocardless_status ) {
+			$response = WC_GoCardless_API::cancel_payment( $payment_id );
+			if ( ! is_wp_error( $response ) ) {
+				wc_gocardless()->log( sprintf( '%s - Payment cancelled', __METHOD__ ) );
+			} else {
+				wc_gocardless()->log( sprintf( '%s - Failed to cancel payment: %s', __METHOD__, $response->get_error_message() ) );
+			}
+		} elseif (
+			! in_array(
+				$gocardless_status,
+				array(
+					'paid_out',
+					'cancelled',
+				),
+				true
+			)
+		) {
+			// We can't cancel the payment, so we update it to not retry if possible to avoid the payment being retried.
+			$response = WC_GoCardless_API::update_payment( $payment_id, array( 'retry_if_possible' => false ) );
+			if ( ! is_wp_error( $response ) ) {
+				wc_gocardless()->log( sprintf( '%s - Payment updated with retry_if_possible set to false', __METHOD__ ) );
+			} else {
+				wc_gocardless()->log( sprintf( '%s - Failed to update payment: %s', __METHOD__, $response->get_error_message() ) );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #72, failed payments continue to be retried by Success+ even after the subscription has been cancelled. This PR improves the handling of GoCardless payments during subscription cancellation:

1. Cancels payments with "pending_submission" status when a subscription is cancelled
2. For payments that cannot be cancelled (status other than "pending_cancellation"), updates them with `retry_if_possible = false` to prevent further retry attempts (except `paid_out` and `cancelled`, as these payment status are already at end status)

Closes #72 

### Steps to test the changes in this Pull Request:
1. Signup to the subscription with GoCardless payment gateway, make sure payment status is `pending_submission`
1. Cancel the subscription (From Frontend or admin panel)
1. Verify that the pending payment is cancelled on the GoCardless side.
1. Create another subscription and update payment status to other than "pending_submission" by simulation scenario (en: submitted)
6. Cancel the subscription
7. Verify that the payment is updated  with `retry_if_possible = false` (you can verify this by clicking on "JSON" in payment details in GoCardless dashboard)

### Changelog entry
> Add - Improved subscription cancellation by cancelling "Pending Submission" payments and preventing retries on non-cancellable payments.