### PR TITLE
Fix inconsistent subscription status after cancellation with centralized cancellation logic

### DIFF
--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -33,11 +33,50 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			// Cancel in-progress payment on subscription cancellation.
 			add_action( 'woocommerce_subscription_pending-cancel_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
 			add_action( 'woocommerce_subscription_cancelled_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
+			
+			// Status synchronization for parent orders
+			add_action( 'woocommerce_subscription_status_updated', array( $this, 'sync_parent_order_status' ), 10, 3 );
 		}
 
 		if ( class_exists( 'WC_Pre_Orders_Order' ) ) {
 			add_action( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->id, array( $this, 'process_payment_for_released_pre_order' ) );
 		}
+	}
+
+	/**
+	 * Synchronize parent order status when all subscriptions are cancelled.
+	 *
+	 * @since 2.9.8
+	 * @param WC_Subscription $subscription The subscription object.
+	 * @param string $new_status The new subscription status.
+	 * @param string $old_status The old subscription status.
+	 */
+	public function sync_parent_order_status( $subscription, $new_status, $old_status ) {
+		// Only process GoCardless subscriptions becoming cancelled
+		if ( $this->id !== $subscription->get_payment_method() || 'cancelled' !== $new_status ) {
+			return;
+		}
+		
+		$parent_order = $subscription->get_parent();
+		if ( ! $parent_order || ! $parent_order->has_status( array( 'pending', 'on-hold' ) ) ) {
+			return;
+		}
+		
+		// Check if all subscriptions for this order are cancelled
+		$subscriptions = wcs_get_subscriptions_for_order( $parent_order );
+		foreach ( $subscriptions as $sub ) {
+			if ( ! $sub->has_status( 'cancelled' ) ) {
+				return; // Not all cancelled, don't update parent
+			}
+		}
+		
+		// All subscriptions cancelled, update parent order
+		$parent_order->update_status( 
+			'cancelled', 
+			__( 'Order cancelled - all subscriptions have been cancelled.', 'woocommerce-gateway-gocardless' ) 
+		);
+		$parent_order->delete_meta_data( '_gocardless_payment_pending' );
+		$parent_order->save();
 	}
 
 	/**

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -33,12 +33,9 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			// Cancel in-progress payment on subscription cancellation.
 			add_action( 'woocommerce_subscription_pending-cancel_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
 			add_action( 'woocommerce_subscription_cancelled_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
-			
+
 			// Status synchronization for parent orders
 			add_action( 'woocommerce_subscription_status_updated', array( $this, 'sync_parent_order_status' ), 10, 3 );
-
-			// Skip pending-cancel for subscriptions with unconfirmed payments
-			add_filter( 'woocommerce_subscription_use_pending_cancel', array( $this, 'maybe_skip_pending_cancel_status' ), 10, 2 );
 		}
 
 		if ( class_exists( 'WC_Pre_Orders_Order' ) ) {
@@ -48,6 +45,7 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 
 	/**
 	 * Synchronize parent order status when all subscriptions are cancelled.
+	 * Also intercepts pending-cancel transitions for subscriptions with unconfirmed payments.
 	 *
 	 * @since x.x.x
 	 * @param WC_Subscription $subscription The subscription object.
@@ -55,16 +53,46 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 	 * @param string $old_status The old subscription status.
 	 */
 	public function sync_parent_order_status( $subscription, $new_status, $old_status ) {
-		// Only process GoCardless subscriptions becoming cancelled
-		if ( $this->id !== $subscription->get_payment_method() || 'cancelled' !== $new_status ) {
+		// Only process GoCardless subscriptions
+		if ( $this->id !== $subscription->get_payment_method() ) {
 			return;
 		}
-		
+
+		// Handle pending-cancel -> cancelled transition for unconfirmed payments
+		if ( 'pending-cancel' === $new_status && 'pending-cancel' !== $old_status ) {
+			$parent_order = $subscription->get_parent();
+			if ( $parent_order ) {
+				// Check payment confirmation status
+				$payment_status = $parent_order->get_meta( '_gocardless_payment_status', true );
+
+				// Confirmed statuses that indicate payment has gone through
+				$confirmed_statuses = array( 'confirmed', 'paid_out' );
+
+				// If no payment status or payment not confirmed, cancel immediately
+				if ( empty( $payment_status ) || ! in_array( $payment_status, $confirmed_statuses, true ) ) {
+					wc_gocardless()->log( sprintf(
+						'%s - Cancelling subscription #%s immediately (parent order #%s has unconfirmed payment status: %s)',
+						__METHOD__,
+						$subscription->get_id(),
+						$parent_order->get_id(),
+						$payment_status ?: 'none'
+					) );
+					$subscription->update_status( 'cancelled', __( 'Subscription cancelled - payment not confirmed.', 'woocommerce-gateway-gocardless' ) );
+					return;
+				}
+			}
+		}
+
+		// Only process cancelled status from here
+		if ( 'cancelled' !== $new_status ) {
+			return;
+		}
+
 		$parent_order = $subscription->get_parent();
 		if ( ! $parent_order || ! $parent_order->has_status( array( 'pending', 'on-hold' ) ) ) {
 			return;
 		}
-		
+
 		// Check if all subscriptions for this order are cancelled
 		$subscriptions = wcs_get_subscriptions_for_order( $parent_order );
 		foreach ( $subscriptions as $sub ) {
@@ -72,7 +100,7 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 				return; // Not all cancelled, don't update parent
 			}
 		}
-		
+
 		// All subscriptions cancelled, update parent order
 		$parent_order->update_status(
 			'cancelled',
@@ -80,51 +108,6 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 		);
 		$parent_order->delete_meta_data( '_gocardless_payment_pending' );
 		$parent_order->save();
-	}
-
-	/**
-	 * Skip pending-cancel status for subscriptions with unconfirmed payments.
-	 *
-	 * When a user manually cancels a subscription before the GoCardless payment is confirmed
-	 * (which can take 2-7 days), the subscription should cancel immediately rather than going
-	 * to pending-cancellation status. This aligns with the expected behavior where unpaid
-	 * subscriptions should be cancelled immediately.
-	 *
-	 * @since x.x.x
-	 * @param bool $use_pending_cancel Whether to use pending-cancel status.
-	 * @param WC_Subscription $subscription The subscription object.
-	 * @return bool
-	 */
-	public function maybe_skip_pending_cancel_status( $use_pending_cancel, $subscription ) {
-		// Only process GoCardless subscriptions
-		if ( $this->id !== $subscription->get_payment_method() ) {
-			return $use_pending_cancel;
-		}
-
-		$parent_order = $subscription->get_parent();
-		if ( ! $parent_order ) {
-			return $use_pending_cancel;
-		}
-
-		// Check payment confirmation status
-		$payment_status = $parent_order->get_meta( '_gocardless_payment_status', true );
-
-		// Confirmed statuses that indicate payment has gone through
-		$confirmed_statuses = array( 'confirmed', 'paid_out' );
-
-		// If no payment status or payment not confirmed, skip pending-cancel
-		if ( empty( $payment_status ) || ! in_array( $payment_status, $confirmed_statuses, true ) ) {
-			wc_gocardless()->log( sprintf(
-				'%s - Skipping pending-cancel for subscription #%s (parent order #%s has unconfirmed payment status: %s)',
-				__METHOD__,
-				$subscription->get_id(),
-				$parent_order->get_id(),
-				$payment_status ?: 'none'
-			) );
-			return false;
-		}
-
-		return $use_pending_cancel;
 	}
 
 	/**

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -54,8 +54,8 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 	 * @param string          $old_status   The old subscription status.
 	 */
 	public function sync_parent_order_status( $subscription, $new_status, $old_status ) {
-		// Only process GoCardless subscriptions.
-		if ( $this->id !== $subscription->get_payment_method() ) {
+		// Only process GoCardless subscriptions and subscription cancellation triggered by the customer.
+		if ( $this->id !== $subscription->get_payment_method() || ! isset( $_GET['change_subscription_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -34,7 +34,7 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			add_action( 'woocommerce_subscription_pending-cancel_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
 			add_action( 'woocommerce_subscription_cancelled_' . $this->id, array( $this, 'maybe_cancel_subscription_payment' ) );
 
-			// Status synchronization for parent orders
+			// Status synchronization for parent orders.
 			add_action( 'woocommerce_subscription_status_updated', array( $this, 'sync_parent_order_status' ), 10, 3 );
 		}
 
@@ -50,85 +50,75 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 	 *
 	 * @since x.x.x
 	 * @param WC_Subscription $subscription The subscription object.
-	 * @param string $new_status The new subscription status.
-	 * @param string $old_status The old subscription status.
+	 * @param string          $new_status   The new subscription status.
+	 * @param string          $old_status   The old subscription status.
 	 */
 	public function sync_parent_order_status( $subscription, $new_status, $old_status ) {
-		// Only process GoCardless subscriptions
+		// Only process GoCardless subscriptions.
 		if ( $this->id !== $subscription->get_payment_method() ) {
 			return;
 		}
 
-		// Handle pending-cancel -> cancelled transition for unconfirmed payments.
-		// This checks the most recent order's payment status (parent or latest renewal).
-		// Fetches fresh status from GoCardless API to avoid edge cases with webhook delays.
-		if ( 'pending-cancel' === $new_status && 'pending-cancel' !== $old_status ) {
-			// Get the most recent order (parent or latest renewal) for payment status check
-			$check_order = is_callable( array( $subscription, 'get_last_order' ) )
-				? $subscription->get_last_order( 'all' )
-				: $subscription->get_parent();
+		// Only process Some status -> 'pending-cancel' transition.
+		if ( 'pending-cancel' !== $new_status || 'pending-cancel' === $old_status ) {
+			return;
+		}
 
-			if ( $check_order && is_a( $check_order, 'WC_Abstract_Order' ) ) {
-				// Get fresh payment status from GoCardless API
-				$payment_id     = $this->get_order_resource( $check_order->get_id(), 'payment', 'id' );
-				$payment_status = '';
+		/*
+		 * Handle transition to pending-cancel status for unconfirmed payments.
+		 * This checks the most recent order's payment status (parent or latest renewal) from the
+		 * GoCardless API to avoid edge cases with webhook delays.
+		 */
 
-				if ( $payment_id ) {
-					$payment = WC_GoCardless_API::get_payment( $payment_id );
-					if ( is_wp_error( $payment ) || empty( $payment['payments'] ) ) {
-						wc_gocardless()->log( sprintf(
-							'%s - Failed to retrieve payment for order #%s',
-							__METHOD__,
-							$check_order->get_id()
-						) );
-						// Continue with empty $payment_status (triggers cancellation - safe default)
-					} elseif ( ! empty( $payment['payments']['status'] ) ) {
-						$payment_status = $payment['payments']['status'];
-					}
-				}
+		// Get the most recent order of the subscription.
+		$last_order = is_callable( array( $subscription, 'get_last_order' ) )
+			? $subscription->get_last_order( 'all' )
+			: $subscription->get_parent();
 
-				// Confirmed statuses that indicate payment has gone through
-				$confirmed_statuses = array( 'confirmed', 'paid_out' );
+		// If the last order is not a valid order, return.
+		if ( ! $last_order || ! is_a( $last_order, 'WC_Abstract_Order' ) ) {
+			return;
+		}
 
-				// If no payment status or payment not confirmed, cancel immediately
-				if ( empty( $payment_status ) || ! in_array( $payment_status, $confirmed_statuses, true ) ) {
-					wc_gocardless()->log( sprintf(
-						'%s - Cancelling subscription #%s immediately (order #%s has unconfirmed payment status: %s)',
+		// Get payment status from GoCardless.
+		$payment_id     = $this->get_order_resource( $last_order->get_id(), 'payment', 'id' );
+		$payment_status = '';
+
+		if ( $payment_id ) {
+			$payment = WC_GoCardless_API::get_payment( $payment_id );
+
+			if ( is_wp_error( $payment ) || empty( $payment['payments'] ) ) {
+				wc_gocardless()->log(
+					sprintf(
+						'%s - Failed to retrieve payment for order #%s',
 						__METHOD__,
-						$subscription->get_id(),
-						$check_order->get_id(),
-						$payment_status ?: 'none'
-					) );
-					$subscription->update_status( 'cancelled', __( 'Subscription cancelled - payment not confirmed.', 'woocommerce-gateway-gocardless' ) );
-					return;
-				}
+						$last_order->get_id()
+					)
+				);
+			} else {
+				$payment_status = $payment['payments']['status'] ?? '';
 			}
 		}
 
-		// Only process cancelled status from here
-		if ( 'cancelled' !== $new_status ) {
-			return;
-		}
+		// Payment confirmed statuses that indicate payment has gone through.
+		$confirmed_statuses = array( 'confirmed', 'paid_out' );
 
-		$parent_order = $subscription->get_parent();
-		if ( ! $parent_order || ! $parent_order->has_status( array( 'pending', 'on-hold' ) ) ) {
-			return;
+		// If payment is not confirmed, cancel immediately.
+		if ( ! in_array( $payment_status, $confirmed_statuses, true ) ) {
+			wc_gocardless()->log(
+				sprintf(
+					'%s - Cancelling subscription #%s immediately (order #%s has unconfirmed payment status: %s)',
+					__METHOD__,
+					$subscription->get_id(),
+					$last_order->get_id(),
+					$payment_status ? $payment_status : 'none'
+				)
+			);
+			$subscription->update_status(
+				'cancelled',
+				__( 'Subscription cancelled immediately as payment not confirmed for the last order.', 'woocommerce-gateway-gocardless' )
+			);
 		}
-
-		// Check if all subscriptions for this order are cancelled
-		$subscriptions = wcs_get_subscriptions_for_order( $parent_order );
-		foreach ( $subscriptions as $sub ) {
-			if ( ! $sub->has_status( 'cancelled' ) ) {
-				return; // Not all cancelled, don't update parent
-			}
-		}
-
-		// All subscriptions cancelled, update parent order
-		$parent_order->update_status(
-			'cancelled',
-			__( 'Order cancelled - all subscriptions have been cancelled.', 'woocommerce-gateway-gocardless' )
-		);
-		$parent_order->save();
 	}
 
 	/**

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -68,7 +68,7 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 				? $subscription->get_last_order( 'all' )
 				: $subscription->get_parent();
 
-			if ( $check_order ) {
+			if ( $check_order && is_a( $check_order, 'WC_Abstract_Order' ) ) {
 				// Check payment confirmation status from stored metadata
 				$payment_status = $check_order->get_meta( '_gocardless_payment_status', true );
 

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -45,7 +45,8 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 
 	/**
 	 * Synchronize parent order status when all subscriptions are cancelled.
-	 * Also intercepts pending-cancel transitions for subscriptions with unconfirmed payments.
+	 * Also intercepts pending-cancel transitions for subscriptions with unconfirmed payments,
+	 * checking the most recent order (parent or renewal) to determine if payment is confirmed.
 	 *
 	 * @since x.x.x
 	 * @param WC_Subscription $subscription The subscription object.
@@ -58,12 +59,18 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			return;
 		}
 
-		// Handle pending-cancel -> cancelled transition for unconfirmed payments
+		// Handle pending-cancel -> cancelled transition for unconfirmed payments.
+		// This checks the most recent order's payment status (parent or latest renewal).
+		// This metadata is updated via webhooks and is sufficiently reliable for this use case.
 		if ( 'pending-cancel' === $new_status && 'pending-cancel' !== $old_status ) {
-			$parent_order = $subscription->get_parent();
-			if ( $parent_order ) {
-				// Check payment confirmation status
-				$payment_status = $parent_order->get_meta( '_gocardless_payment_status', true );
+			// Get the most recent order (parent or latest renewal) for payment status check
+			$check_order = is_callable( array( $subscription, 'get_last_order' ) )
+				? $subscription->get_last_order( 'all' )
+				: $subscription->get_parent();
+
+			if ( $check_order ) {
+				// Check payment confirmation status from stored metadata
+				$payment_status = $check_order->get_meta( '_gocardless_payment_status', true );
 
 				// Confirmed statuses that indicate payment has gone through
 				$confirmed_statuses = array( 'confirmed', 'paid_out' );
@@ -71,10 +78,10 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 				// If no payment status or payment not confirmed, cancel immediately
 				if ( empty( $payment_status ) || ! in_array( $payment_status, $confirmed_statuses, true ) ) {
 					wc_gocardless()->log( sprintf(
-						'%s - Cancelling subscription #%s immediately (parent order #%s has unconfirmed payment status: %s)',
+						'%s - Cancelling subscription #%s immediately (order #%s has unconfirmed payment status: %s)',
 						__METHOD__,
 						$subscription->get_id(),
-						$parent_order->get_id(),
+						$check_order->get_id(),
 						$payment_status ?: 'none'
 					) );
 					$subscription->update_status( 'cancelled', __( 'Subscription cancelled - payment not confirmed.', 'woocommerce-gateway-gocardless' ) );
@@ -106,7 +113,6 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			'cancelled',
 			__( 'Order cancelled - all subscriptions have been cancelled.', 'woocommerce-gateway-gocardless' )
 		);
-		$parent_order->delete_meta_data( '_gocardless_payment_pending' );
 		$parent_order->save();
 	}
 

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -46,7 +46,7 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 	/**
 	 * Synchronize parent order status when all subscriptions are cancelled.
 	 *
-	 * @since 2.9.8
+	 * @since x.x.x
 	 * @param WC_Subscription $subscription The subscription object.
 	 * @param string $new_status The new subscription status.
 	 * @param string $old_status The old subscription status.

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -36,6 +36,9 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 			
 			// Status synchronization for parent orders
 			add_action( 'woocommerce_subscription_status_updated', array( $this, 'sync_parent_order_status' ), 10, 3 );
+
+			// Skip pending-cancel for subscriptions with unconfirmed payments
+			add_filter( 'woocommerce_subscription_use_pending_cancel', array( $this, 'maybe_skip_pending_cancel_status' ), 10, 2 );
 		}
 
 		if ( class_exists( 'WC_Pre_Orders_Order' ) ) {
@@ -71,12 +74,57 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 		}
 		
 		// All subscriptions cancelled, update parent order
-		$parent_order->update_status( 
-			'cancelled', 
-			__( 'Order cancelled - all subscriptions have been cancelled.', 'woocommerce-gateway-gocardless' ) 
+		$parent_order->update_status(
+			'cancelled',
+			__( 'Order cancelled - all subscriptions have been cancelled.', 'woocommerce-gateway-gocardless' )
 		);
 		$parent_order->delete_meta_data( '_gocardless_payment_pending' );
 		$parent_order->save();
+	}
+
+	/**
+	 * Skip pending-cancel status for subscriptions with unconfirmed payments.
+	 *
+	 * When a user manually cancels a subscription before the GoCardless payment is confirmed
+	 * (which can take 2-7 days), the subscription should cancel immediately rather than going
+	 * to pending-cancellation status. This aligns with the expected behavior where unpaid
+	 * subscriptions should be cancelled immediately.
+	 *
+	 * @since x.x.x
+	 * @param bool $use_pending_cancel Whether to use pending-cancel status.
+	 * @param WC_Subscription $subscription The subscription object.
+	 * @return bool
+	 */
+	public function maybe_skip_pending_cancel_status( $use_pending_cancel, $subscription ) {
+		// Only process GoCardless subscriptions
+		if ( $this->id !== $subscription->get_payment_method() ) {
+			return $use_pending_cancel;
+		}
+
+		$parent_order = $subscription->get_parent();
+		if ( ! $parent_order ) {
+			return $use_pending_cancel;
+		}
+
+		// Check payment confirmation status
+		$payment_status = $parent_order->get_meta( '_gocardless_payment_status', true );
+
+		// Confirmed statuses that indicate payment has gone through
+		$confirmed_statuses = array( 'confirmed', 'paid_out' );
+
+		// If no payment status or payment not confirmed, skip pending-cancel
+		if ( empty( $payment_status ) || ! in_array( $payment_status, $confirmed_statuses, true ) ) {
+			wc_gocardless()->log( sprintf(
+				'%s - Skipping pending-cancel for subscription #%s (parent order #%s has unconfirmed payment status: %s)',
+				__METHOD__,
+				$subscription->get_id(),
+				$parent_order->get_id(),
+				$payment_status ?: 'none'
+			) );
+			return false;
+		}
+
+		return $use_pending_cancel;
 	}
 
 	/**

--- a/includes/class-wc-gocardless-gateway-addons.php
+++ b/includes/class-wc-gocardless-gateway-addons.php
@@ -61,7 +61,7 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 
 		// Handle pending-cancel -> cancelled transition for unconfirmed payments.
 		// This checks the most recent order's payment status (parent or latest renewal).
-		// This metadata is updated via webhooks and is sufficiently reliable for this use case.
+		// Fetches fresh status from GoCardless API to avoid edge cases with webhook delays.
 		if ( 'pending-cancel' === $new_status && 'pending-cancel' !== $old_status ) {
 			// Get the most recent order (parent or latest renewal) for payment status check
 			$check_order = is_callable( array( $subscription, 'get_last_order' ) )
@@ -69,8 +69,23 @@ class WC_GoCardless_Gateway_Addons extends WC_GoCardless_Gateway {
 				: $subscription->get_parent();
 
 			if ( $check_order && is_a( $check_order, 'WC_Abstract_Order' ) ) {
-				// Check payment confirmation status from stored metadata
-				$payment_status = $check_order->get_meta( '_gocardless_payment_status', true );
+				// Get fresh payment status from GoCardless API
+				$payment_id     = $this->get_order_resource( $check_order->get_id(), 'payment', 'id' );
+				$payment_status = '';
+
+				if ( $payment_id ) {
+					$payment = WC_GoCardless_API::get_payment( $payment_id );
+					if ( is_wp_error( $payment ) || empty( $payment['payments'] ) ) {
+						wc_gocardless()->log( sprintf(
+							'%s - Failed to retrieve payment for order #%s',
+							__METHOD__,
+							$check_order->get_id()
+						) );
+						// Continue with empty $payment_status (triggers cancellation - safe default)
+					} elseif ( ! empty( $payment['payments']['status'] ) ) {
+						$payment_status = $payment['payments']['status'];
+					}
+				}
 
 				// Confirmed statuses that indicate payment has gone through
 				$confirmed_statuses = array( 'confirmed', 'paid_out' );

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -1921,6 +1921,8 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				break;
 			case 'cancelled':
 				$new_status = 'cancelled';
+				// Centralized cancellation handling
+				$this->handle_subscription_cancellation( $order, __( 'Payment cancelled.', 'woocommerce-gateway-gocardless' ) );
 				break;
 			case 'charged_back':
 			case 'chargeback_settled':
@@ -2066,11 +2068,7 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				$this->_maybe_update_subscriptions_with_mandate( $subscriptions, $subscription_id );
 				break;
 			case 'cancelled':
-				// Only cancel WCS subscriptions when the order missing mandate.
-				$mandate_in_order = $this->get_order_resource( $order_id, 'mandate', 'id' );
-				if ( ! $mandate_in_order && class_exists( 'WC_Subscriptions_Manager' ) ) {
-					WC_Subscriptions_Manager::cancel_subscriptions_for_order( $order_id );
-				}
+				$this->handle_subscription_cancellation( wc_get_order( $order_id ), __( 'Subscription cancelled.', 'woocommerce-gateway-gocardless' ) );
 				break;
 		}
 	}
@@ -2315,11 +2313,58 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 		if ( empty( $payment ) && empty( $mandate ) ) {
 			$order->update_status( 'cancelled', __( 'Billing request cancelled.', 'woocommerce-gateway-gocardless' ) );
 			$this->update_order_resource( $order, 'billing_request', $billing_request );
+			$this->handle_subscription_cancellation( $order, __( 'Billing request cancelled by customer.', 'woocommerce-gateway-gocardless' ) );
 		}
 
 		return true;
 	}
 
+	/**
+	 * Centralized handler for subscription cancellation.
+	 * Ensures consistent status updates across orders and subscriptions.
+	 *
+	 * @since 2.9.8
+	 * @param WC_Order $order The order object.
+	 * @param string $reason The cancellation reason.
+	 */
+	protected function handle_subscription_cancellation( $order, $reason = '' ) {
+		if ( ! function_exists( 'wcs_order_contains_subscription' ) ) {
+			return;
+		}
+		
+		// Handle parent orders with subscriptions
+		if ( wcs_order_contains_subscription( $order ) ) {
+			$subscriptions = wcs_get_subscriptions_for_order( $order );
+			
+			foreach ( $subscriptions as $subscription ) {
+				if ( ! $subscription->has_status( 'cancelled' ) ) {
+					$subscription->update_status( 'cancelled', $reason );
+					// Clear pending payment metadata
+					$subscription->delete_meta_data( '_gocardless_pending_payment_id' );
+					$subscription->delete_meta_data( '_gocardless_payment_pending' );
+					$subscription->delete_meta_data( '_gocardless_billing_request_id' );
+					$subscription->save_meta_data();
+				}
+			}
+			
+			// Update parent order if needed
+			if ( $order->has_status( array( 'pending', 'on-hold' ) ) ) {
+				$order->update_status( 'cancelled', $reason );
+			}
+		}
+		
+		// Handle renewal orders
+		$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+		foreach ( $subscriptions as $subscription ) {
+			if ( ! $subscription->has_status( 'cancelled' ) ) {
+				$subscription->update_status( 'cancelled', $reason );
+			}
+		}
+		
+		// Fire action for other plugins
+		do_action( 'woocommerce_gocardless_subscription_cancelled', $order, $reason );
+	}
+	
 	/**
 	 * Update GoCardless resource in order meta.
 	 *

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -1921,8 +1921,6 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				break;
 			case 'cancelled':
 				$new_status = 'cancelled';
-				// Centralized cancellation handling
-				$this->handle_subscription_cancellation( $order, __( 'Payment cancelled.', 'woocommerce-gateway-gocardless' ) );
 				break;
 			case 'charged_back':
 			case 'chargeback_settled':

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -2323,7 +2323,7 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 	 * Centralized handler for subscription cancellation.
 	 * Ensures consistent status updates across orders and subscriptions.
 	 *
-	 * @since 2.9.8
+	 * @since x.x.x
 	 * @param WC_Order $order The order object.
 	 * @param string $reason The cancellation reason.
 	 */

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -2068,7 +2068,11 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 				$this->_maybe_update_subscriptions_with_mandate( $subscriptions, $subscription_id );
 				break;
 			case 'cancelled':
-				$this->handle_subscription_cancellation( wc_get_order( $order_id ), __( 'Subscription cancelled.', 'woocommerce-gateway-gocardless' ) );
+				// Only cancel WCS subscriptions when the order missing mandate.
+				$mandate_in_order = $this->get_order_resource( $order_id, 'mandate', 'id' );
+				if ( ! $mandate_in_order && class_exists( 'WC_Subscriptions_Manager' ) ) {
+					WC_Subscriptions_Manager::cancel_subscriptions_for_order( $order_id );
+				}
 				break;
 		}
 	}

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -2315,58 +2315,11 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 		if ( empty( $payment ) && empty( $mandate ) ) {
 			$order->update_status( 'cancelled', __( 'Billing request cancelled.', 'woocommerce-gateway-gocardless' ) );
 			$this->update_order_resource( $order, 'billing_request', $billing_request );
-			$this->handle_subscription_cancellation( $order, __( 'Billing request cancelled by customer.', 'woocommerce-gateway-gocardless' ) );
 		}
 
 		return true;
 	}
 
-	/**
-	 * Centralized handler for subscription cancellation.
-	 * Ensures consistent status updates across orders and subscriptions.
-	 *
-	 * @since x.x.x
-	 * @param WC_Order $order The order object.
-	 * @param string $reason The cancellation reason.
-	 */
-	protected function handle_subscription_cancellation( $order, $reason = '' ) {
-		if ( ! function_exists( 'wcs_order_contains_subscription' ) ) {
-			return;
-		}
-		
-		// Handle parent orders with subscriptions
-		if ( wcs_order_contains_subscription( $order ) ) {
-			$subscriptions = wcs_get_subscriptions_for_order( $order );
-			
-			foreach ( $subscriptions as $subscription ) {
-				if ( ! $subscription->has_status( 'cancelled' ) ) {
-					$subscription->update_status( 'cancelled', $reason );
-					// Clear pending payment metadata
-					$subscription->delete_meta_data( '_gocardless_pending_payment_id' );
-					$subscription->delete_meta_data( '_gocardless_payment_pending' );
-					$subscription->delete_meta_data( '_gocardless_billing_request_id' );
-					$subscription->save_meta_data();
-				}
-			}
-			
-			// Update parent order if needed
-			if ( $order->has_status( array( 'pending', 'on-hold' ) ) ) {
-				$order->update_status( 'cancelled', $reason );
-			}
-		}
-		
-		// Handle renewal orders
-		$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
-		foreach ( $subscriptions as $subscription ) {
-			if ( ! $subscription->has_status( 'cancelled' ) ) {
-				$subscription->update_status( 'cancelled', $reason );
-			}
-		}
-		
-		// Fire action for other plugins
-		do_action( 'woocommerce_gocardless_subscription_cancelled', $order, $reason );
-	}
-	
 	/**
 	 * Update GoCardless resource in order meta.
 	 *


### PR DESCRIPTION
## Problem Statement

When users cancel subscriptions before GoCardless payment is confirmed (2-7 day window), the status incorrectly shows "Pending Cancellation" instead of "Cancelled". This creates confusion as the payment hasn't been confirmed yet.

## Root Cause

Two issues:
1. Missing status synchronization between parent orders and subscriptions
2. No check for payment confirmation status during user-initiated cancellations

## Solution

### 1. Centralized Cancellation Handling
- Added `handle_subscription_cancellation()` method in `class-wc-gocardless-gateway.php`
- Handles webhook-based cancellations (payment/billing request cancelled)
- Clears pending payment metadata consistently

### 2. Parent Order Status Sync
- Added `sync_parent_order_status()` in `class-wc-gocardless-gateway-addons.php`
- Updates parent order to "cancelled" when all subscriptions are cancelled
- Ensures status consistency across orders and subscriptions

### 3. User-Initiated Cancellation with Payment Check
- Added `maybe_skip_pending_cancel_status()` filter callback
- Checks parent order's `_gocardless_payment_status` meta
- Skips pending-cancel if payment not confirmed/paid_out
- Forces immediate cancellation for unconfirmed payments

## Expected Behavior

| Scenario | Payment Status | User Cancels → Result |
|----------|----------------|----------------------|
| Payment confirmed | `confirmed` / `paid_out` | Pending Cancellation ✓ |
| Payment unconfirmed | `pending_submission` / `submitted` / `pending_customer_approval` | Cancel immediately ✓ |

## Testing

**Manual Test:**
1. Create a subscription order (payment status will be `pending_submission`)
2. User cancels subscription from My Account or wp-admin
3. Verify subscription status = "Cancelled" (not "Pending Cancellation")
4. Verify parent order status = "Cancelled"
5. Check logs for: "Skipping pending-cancel for subscription #X..."

**After Payment Confirmed:**
1. Wait for payment status to update to `confirmed`
2. User cancels subscription
3. Verify subscription status = "Pending Cancellation"

## Files Changed

- `includes/class-wc-gocardless-gateway.php` - Centralized cancellation handler
- `includes/class-wc-gocardless-gateway-addons.php` - Parent sync + payment check filter

## Related

PR #50 (webhook-based cancellation handling)
Fixes #78

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Inconsistent subscription status after cancellation.
