### PR TITLE
Fix webhook race condition where paid_out event arrives after failed …

### DIFF
--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -1894,11 +1894,21 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 			return false;
 		}
 
-		wc_gocardless()->log( sprintf( '%s - Handling payment event with action "%s" for order #%s', __METHOD__, $event['action'], $order->get_order_number() ) );
+		wc_gocardless()->log( sprintf( '%s - Handling payment event with action "%s" for order #%s (current status: %s)', __METHOD__, $event['action'], $order->get_order_number(), $order->get_status() ) );
 		$new_status = '';
 		switch ( $event['action'] ) {
 			case 'paid_out':
 			case 'confirmed':
+				// Handle case where paid_out event arrives after failed event
+				// This fixes issue #7: https://github.com/gocardless/woocommerce-gateway-gocardless/issues/7
+				$current_status = $order->get_status();
+				if ( 'failed' === $current_status ) {
+					wc_gocardless()->log( sprintf( '%s - Order #%s is in failed status, transitioning to processing before payment_complete()', __METHOD__, $order->get_order_number() ) );
+					$order->update_status( 'processing', __( 'Payment received after initial failure - updating status', 'woocommerce-gateway-gocardless' ) );
+				} elseif ( 'cancelled' === $current_status ) {
+					wc_gocardless()->log( sprintf( '%s - Order #%s is in cancelled status, transitioning to processing before payment_complete()', __METHOD__, $order->get_order_number() ) );
+					$order->update_status( 'processing', __( 'Payment received after cancellation - updating status', 'woocommerce-gateway-gocardless' ) );
+				}
 				$order->payment_complete( $event['links']['payment'] );
 				break;
 			case 'failed':

--- a/tests/phpunit/test-webhook-race-condition.php
+++ b/tests/phpunit/test-webhook-race-condition.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for webhook race condition fix.
+ * Tests the scenario where a paid_out event arrives after a failed event.
+ */
+class WebhookRaceConditionTests extends TestCase {
+	/**
+	 * Set up our mocked WP functions.
+	 *
+	 * @return void
+	 */
+	public function setUp() : void {
+		\WP_Mock::setUp();
+	}
+
+	/**
+	 * Tear down WP Mock.
+	 *
+	 * @return void
+	 */
+	public function tearDown() : void {
+		\WP_Mock::tearDown();
+	}
+
+	/**
+	 * Test that paid_out event after failed event properly transitions order status.
+	 */
+	public function test_paid_out_after_failed_event() {
+		// Mock the order object
+		$order = \Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_status' )->andReturn( 'failed' );
+		$order->shouldReceive( 'get_order_number' )->andReturn( '12345' );
+		$order->shouldReceive( 'update_status' )->with( 'processing', 'Payment received after initial failure - updating status' )->once();
+		$order->shouldReceive( 'payment_complete' )->with( 'payment_123' )->once();
+
+		// Mock the gateway
+		$gateway = \Mockery::mock( 'WC_GoCardless_Gateway' );
+		$gateway->shouldReceive( 'get_order_from_resource' )->andReturn( $order );
+
+		// Mock wc_gocardless_get_order_prop
+		\WP_Mock::userFunction( 'wc_gocardless_get_order_prop' )
+			->with( $order, 'id' )
+			->andReturn( 123 );
+		\WP_Mock::userFunction( 'wc_gocardless_get_order_prop' )
+			->with( $order, 'payment_method' )
+			->andReturn( 'gocardless' );
+
+		// Mock wc_gocardless function
+		$wc_gocardless_mock = \Mockery::mock();
+		$wc_gocardless_mock->shouldReceive( 'log' )->andReturn( true );
+		\WP_Mock::userFunction( 'wc_gocardless' )->andReturn( $wc_gocardless_mock );
+
+		// Create the event payload
+		$event = array(
+			'action' => 'paid_out',
+			'links'  => array(
+				'payment' => 'payment_123',
+			),
+		);
+
+		// Use reflection to access the protected method
+		$reflection = new ReflectionClass( $gateway );
+		$method = $reflection->getMethod( '_process_payment_event' );
+		$method->setAccessible( true );
+
+		// Execute the method
+		$result = $method->invoke( $gateway, $event );
+
+		// Assert the method returns true
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that paid_out event after cancelled event properly transitions order status.
+	 */
+	public function test_paid_out_after_cancelled_event() {
+		// Mock the order object
+		$order = \Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_status' )->andReturn( 'cancelled' );
+		$order->shouldReceive( 'get_order_number' )->andReturn( '12345' );
+		$order->shouldReceive( 'update_status' )->with( 'processing', 'Payment received after cancellation - updating status' )->once();
+		$order->shouldReceive( 'payment_complete' )->with( 'payment_123' )->once();
+
+		// Mock the gateway
+		$gateway = \Mockery::mock( 'WC_GoCardless_Gateway' );
+		$gateway->shouldReceive( 'get_order_from_resource' )->andReturn( $order );
+
+		// Mock wc_gocardless_get_order_prop
+		\WP_Mock::userFunction( 'wc_gocardless_get_order_prop' )
+			->with( $order, 'id' )
+			->andReturn( 123 );
+		\WP_Mock::userFunction( 'wc_gocardless_get_order_prop' )
+			->with( $order, 'payment_method' )
+			->andReturn( 'gocardless' );
+
+		// Mock wc_gocardless function
+		$wc_gocardless_mock = \Mockery::mock();
+		$wc_gocardless_mock->shouldReceive( 'log' )->andReturn( true );
+		\WP_Mock::userFunction( 'wc_gocardless' )->andReturn( $wc_gocardless_mock );
+
+		// Create the event payload
+		$event = array(
+			'action' => 'paid_out',
+			'links'  => array(
+				'payment' => 'payment_123',
+			),
+		);
+
+		// Use reflection to access the protected method
+		$reflection = new ReflectionClass( $gateway );
+		$method = $reflection->getMethod( '_process_payment_event' );
+		$method->setAccessible( true );
+
+		// Execute the method
+		$result = $method->invoke( $gateway, $event );
+
+		// Assert the method returns true
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that paid_out event with normal status doesn't trigger status change.
+	 */
+	public function test_paid_out_with_normal_status() {
+		// Mock the order object
+		$order = \Mockery::mock( 'WC_Order' );
+		$order->shouldReceive( 'get_status' )->andReturn( 'processing' );
+		$order->shouldReceive( 'get_order_number' )->andReturn( '12345' );
+		$order->shouldReceive( 'update_status' )->never();
+		$order->shouldReceive( 'payment_complete' )->with( 'payment_123' )->once();
+
+		// Mock the gateway
+		$gateway = \Mockery::mock( 'WC_GoCardless_Gateway' );
+		$gateway->shouldReceive( 'get_order_from_resource' )->andReturn( $order );
+
+		// Mock wc_gocardless_get_order_prop
+		\WP_Mock::userFunction( 'wc_gocardless_get_order_prop' )
+			->with( $order, 'id' )
+			->andReturn( 123 );
+		\WP_Mock::userFunction( 'wc_gocardless_get_order_prop' )
+			->with( $order, 'payment_method' )
+			->andReturn( 'gocardless' );
+
+		// Mock wc_gocardless function
+		$wc_gocardless_mock = \Mockery::mock();
+		$wc_gocardless_mock->shouldReceive( 'log' )->andReturn( true );
+		\WP_Mock::userFunction( 'wc_gocardless' )->andReturn( $wc_gocardless_mock );
+
+		// Create the event payload
+		$event = array(
+			'action' => 'paid_out',
+			'links'  => array(
+				'payment' => 'payment_123',
+			),
+		);
+
+		// Use reflection to access the protected method
+		$reflection = new ReflectionClass( $gateway );
+		$method = $reflection->getMethod( '_process_payment_event' );
+		$method->setAccessible( true );
+
+		// Execute the method
+		$result = $method->invoke( $gateway, $event );
+
+		// Assert the method returns true
+		$this->assertTrue( $result );
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes the race condition described in issue #7 where a `paid_out` event arrives after a `failed` event, causing orders to remain in failed status even though the payment was successful.

## Problem

- GoCardless webhook events can arrive out of order due to network delays or retries
- When a `failed` event arrives first, it sets the order status to `failed` and removes `_gocardless_temporary_activated`
- A subsequent `paid_out` event calls `payment_complete()` but the order is already in `failed` state
- This causes the payment completion to fail or not properly transition the order status

## Solution

- Check if order is in `failed` or `cancelled` status when `paid_out`/`confirmed` events are received
- Transition order status to `processing` before calling `payment_complete()`
- Add comprehensive logging for debugging race conditions
- Include unit tests for all scenarios

## Changes

- **Modified**: `includes/class-wc-gocardless-gateway.php`
  - Enhanced `_process_payment_event()` method to handle race conditions
  - Added status transition logic for `failed` → `paid_out` and `cancelled` → `paid_out` scenarios
  - Improved logging to track current order status during webhook processing

- **Added**: `tests/phpunit/test-webhook-race-condition.php`
  - Unit tests for all race condition scenarios
  - Tests verify proper status transitions and method calls
  - Ensures backward compatibility with normal processing flow

## Testing

- ✅ Unit tests cover all scenarios (failed→paid_out, cancelled→paid_out, normal flow)
- ✅ No linting errors introduced
- ✅ Backward compatible with existing functionality
- ✅ Comprehensive logging for debugging

## Fixes

#7