### PR TITLE
Automatically disconnect the GoCardless account and display a reconnect notice when the token becomes invalid or inactive.

### DIFF
--- a/includes/class-wc-gocardless-api.php
+++ b/includes/class-wc-gocardless-api.php
@@ -174,7 +174,8 @@ class WC_GoCardless_API {
 			return $resp;
 		}
 
-		$parsed_resp = json_decode( wp_remote_retrieve_body( $resp ), true );
+		$response_code = wp_remote_retrieve_response_code( $resp );
+		$parsed_resp   = json_decode( wp_remote_retrieve_body( $resp ), true );
 		if ( is_null( $parsed_resp ) ) {
 			wc_gocardless()->log( sprintf( '%s - Failed to decode JSON resp %s', __METHOD__, print_r( wp_remote_retrieve_body( $resp ), true ) ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			return new WP_Error( 'error_json_decode', esc_html__( 'Error decoding JSON response', 'woocommerce-gateway-gocardless' ) );
@@ -196,6 +197,30 @@ class WC_GoCardless_API {
 				'Forbidden request' === $message
 			) {
 				return new WP_Error( 'error_gocardless_create_refund', esc_html__( 'GoCardless refund endpoint is disabled by default. Please contact api@gocardless.com to enable it for you.', 'woocommerce-gateway-gocardless' ) );
+			}
+
+			/*
+			 * Error Handling for 401 unauthorized response code.
+			 *
+			 * If API respond with 401 unauthorized response code, it means:
+			 *
+			 * - `access_token_not_found` (the access token was not recognised); or
+			 * - `access_token_revoked` (the user has revoked your access to their account); or
+			 * - `access_token_not_active` (the access token is inactive for another reason)
+			 *
+			 * We need to disconnect from GoCardless and display a notice to the user to connect again.
+			 */
+			if ( 401 === $response_code && 'invalid_api_usage' === $parsed_resp['error']['type'] ) {
+				// Unauthorized response code, disconnect from GoCardless.
+				wc_gocardless()->log( sprintf( '%s - Unauthorized response code, disconnecting from GoCardless', __METHOD__ ) );
+				$settings = get_option( 'woocommerce_gocardless_settings', array() );
+				$settings['access_token'] = '';
+				update_option( 'woocommerce_gocardless_settings', $settings );
+
+				wc_gocardless()->log( sprintf( '%s - Disconnected from GoCardless', __METHOD__ ) );
+
+				// Add option to display notice to connect GoCardless again.
+				update_option( 'wc_gocardless_access_token_unauthorized', true );
 			}
 
 			$new_mandate = null;

--- a/includes/class-wc-gocardless-api.php
+++ b/includes/class-wc-gocardless-api.php
@@ -213,7 +213,7 @@ class WC_GoCardless_API {
 			if ( 401 === $response_code && 'invalid_api_usage' === $parsed_resp['error']['type'] ) {
 				// Unauthorized response code, disconnect from GoCardless.
 				wc_gocardless()->log( sprintf( '%s - Unauthorized response code, disconnecting from GoCardless', __METHOD__ ) );
-				$settings = get_option( 'woocommerce_gocardless_settings', array() );
+				$settings                 = get_option( 'woocommerce_gocardless_settings', array() );
 				$settings['access_token'] = '';
 				update_option( 'woocommerce_gocardless_settings', $settings );
 

--- a/includes/class-wc-gocardless-api.php
+++ b/includes/class-wc-gocardless-api.php
@@ -217,6 +217,9 @@ class WC_GoCardless_API {
 				$settings['access_token'] = '';
 				update_option( 'woocommerce_gocardless_settings', $settings );
 
+				// Clear the available scheme transient.
+				delete_transient( 'wc_gocardless_available_scheme_identifiers' );
+
 				wc_gocardless()->log( sprintf( '%s - Disconnected from GoCardless', __METHOD__ ) );
 
 				// Add option to display notice to connect GoCardless again.

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -2924,7 +2924,7 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function get_available_scheme_identifiers() {
-		$transient_key = 'wc_gocardless_available_scheme_identifiers2';
+		$transient_key = 'wc_gocardless_available_scheme_identifiers';
 		$schemes       = get_transient( $transient_key );
 		if ( false !== $schemes ) {
 			return $schemes;

--- a/includes/class-wc-gocardless-gateway.php
+++ b/includes/class-wc-gocardless-gateway.php
@@ -159,6 +159,9 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 		// Clear the available scheme transient.
 		delete_transient( 'wc_gocardless_available_scheme_identifiers' );
 
+		// Clear option which displays notice to connect GoCardless.
+		delete_option( 'wc_gocardless_access_token_unauthorized' );
+
 		// Delete notice that informs merchant to connect with GoCardless.
 		WC_Admin_Notices::remove_notice( 'gocardless_connect_prompt' );
 
@@ -2921,7 +2924,7 @@ class WC_GoCardless_Gateway extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function get_available_scheme_identifiers() {
-		$transient_key = 'wc_gocardless_available_scheme_identifiers';
+		$transient_key = 'wc_gocardless_available_scheme_identifiers2';
 		$schemes       = get_transient( $transient_key );
 		if ( false !== $schemes ) {
 			return $schemes;

--- a/includes/class-wc-gocardless-order-admin.php
+++ b/includes/class-wc-gocardless-order-admin.php
@@ -600,13 +600,14 @@ class WC_GoCardless_Order_Admin {
 			<?php
 			echo wp_kses(
 				sprintf(
-					__( 'GoCardless account was disconnected because the access token is no longer active or valid. Please <a href="%s">reconnect</a> your GoCardless account to continue accepting payments.', 'woocommerce-gateway-gocardless' ),
+					__( 'The connection to your <strong>GoCardless</strong> account has been disconnected because the access token is no longer active or valid. Please <a href="%s">connect</a> your GoCardless account to continue accepting payments.', 'woocommerce-gateway-gocardless' ),
 					wc_gocardless()->get_setting_url()
 				),
 				array(
 					'a' => array(
 						'href' => array(),
 					),
+					'strong' => array(),
 				)
 			);
 			?>

--- a/includes/class-wc-gocardless-order-admin.php
+++ b/includes/class-wc-gocardless-order-admin.php
@@ -25,6 +25,7 @@ class WC_GoCardless_Order_Admin {
 		$this->add_order_actions();
 
 		add_action( 'admin_notices', array( $this, 'display_connection_notices' ) );
+		add_action( 'admin_notices', array( $this, 'display_access_token_unauthorized_notice' ) );
 
 		// GoCardless Connect/Disconnect actions.
 		add_action( 'admin_post_wc_connect_gocardless', array( $this, 'connect_gocardless' ) );
@@ -575,5 +576,42 @@ class WC_GoCardless_Order_Admin {
 		delete_transient( 'wc_gocardless_connection_notice' );
 
 		return $notice;
+	}
+
+	/**
+	 * Display notice for access token unauthorized.
+	 *
+	 * @since x.x.x
+	 */
+	public function display_access_token_unauthorized_notice() {
+		// Check if option is set to display notice.
+		if ( ! get_option( 'wc_gocardless_access_token_unauthorized' ) ) {
+			return;
+		}
+
+		// Check if access token is there.
+		$settings = get_option( 'woocommerce_gocardless_settings', array() );
+		if ( ! empty( $settings['access_token'] ) ) {
+			return;
+		}
+		?>
+		<div class="notice notice-warning">
+			<p>
+			<?php
+			echo wp_kses(
+				sprintf(
+					__( 'GoCardless account was disconnected because the access token is no longer active or valid. Please <a href="%s">reconnect</a> your GoCardless account to continue accepting payments.', 'woocommerce-gateway-gocardless' ),
+					wc_gocardless()->get_setting_url()
+				),
+				array(
+					'a' => array(
+						'href' => array(),
+					),
+				)
+			);
+			?>
+			</p>
+		</div>
+		<?php
 	}
 }

--- a/includes/class-wc-gocardless-order-admin.php
+++ b/includes/class-wc-gocardless-order-admin.php
@@ -592,6 +592,8 @@ class WC_GoCardless_Order_Admin {
 		// Check if access token is there.
 		$settings = get_option( 'woocommerce_gocardless_settings', array() );
 		if ( ! empty( $settings['access_token'] ) ) {
+			// Remove the option to display notice, as we have an access token now (in case it missed to remove while connect to GoCardless).
+			delete_option( 'wc_gocardless_access_token_unauthorized' );
 			return;
 		}
 		?>

--- a/includes/class-wc-gocardless-order-admin.php
+++ b/includes/class-wc-gocardless-order-admin.php
@@ -600,11 +600,12 @@ class WC_GoCardless_Order_Admin {
 			<?php
 			echo wp_kses(
 				sprintf(
+					/* translators: %s: settings URL */
 					__( 'The connection to your <strong>GoCardless</strong> account has been disconnected because the access token is no longer active or valid. Please <a href="%s">connect</a> your GoCardless account to continue accepting payments.', 'woocommerce-gateway-gocardless' ),
 					wc_gocardless()->get_setting_url()
 				),
 				array(
-					'a' => array(
+					'a'      => array(
 						'href' => array(),
 					),
 					'strong' => array(),

--- a/tests/e2e/specs/admin.spec.js
+++ b/tests/e2e/specs/admin.spec.js
@@ -14,6 +14,7 @@ const {
 	goToCheckout,
 	saveSettings,
 	fillBillingDetails,
+	updateAccessToken,
 } = require('../utils');
 const {
 	paymentMethodTitle,
@@ -339,5 +340,41 @@ test.describe('Admin Tests', () => {
 			page.locator('span[aria-label="sepa"]').first()
 		).not.toBeAttached();
 		await goToCheckout(page);
+	});
+
+	test('GoCardless account should disconnect and display notice if access token is invalid - @foundational', async ({
+		page,
+		browser,
+	}) => {
+		// Make sure GoCardless is connected.
+		await connectWithGoCardless(page);
+
+		// Update the access token to invalid.
+		await updateAccessToken(page, 'invalid_access_token');
+
+		await page.goto(
+			'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=gocardless'
+		);
+
+		// Reload the page.
+		await page.goto(
+			'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=gocardless'
+		);
+
+		await expect(
+			page.locator('.notice-warning p', { hasText: /The connection to your GoCardless account has been disconnected because the access token is no longer active or valid/ })
+		).toBeVisible();
+
+		// Connect with GoCardless again and make sure the notice is no longer visible.
+		const adminPage = await browser.newPage({
+			storageState: process.env.ADMINSTATE,
+		});
+		await connectWithGoCardless(adminPage);
+		await adminPage.goto(
+			'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=gocardless'
+		);
+		await expect(
+			adminPage.locator('.notice-warning p', { hasText: /The connection to your GoCardless account has been disconnected because the access token is no longer active or valid/ })
+		).not.toBeVisible();
 	});
 });

--- a/tests/e2e/test-plugins/e2e-test-plugin/e2e-test-plugin.php
+++ b/tests/e2e/test-plugins/e2e-test-plugin/e2e-test-plugin.php
@@ -291,3 +291,51 @@ function test_wc_gocardless_simulate_billing_request_fulfilled_webhook() {
 		]
 	);
 }
+
+/**
+ * Registers a REST API endpoint to update the access token.
+ * This is used in E2E tests to update the access token.
+ *
+ * Route: POST /wp-json/gocardless-e2e/v1/update-access-token
+ * Body:  { "access_token": "1234567890" }
+ */
+add_action( 'rest_api_init', function () {
+	register_rest_route( 'gocardless-e2e/v1', '/update-access-token', array(
+		'methods'             => 'POST',
+		'callback'            => 'gocardless_e2e_update_access_token_callback',
+		'permission_callback' => '__return_true',
+		'args'                => array(
+			'access_token' => array(
+				'type'     => 'string',
+				'required' => true,
+			),
+		),
+	) );
+} );
+
+/**
+ * Updates the access token.
+ *
+ * @param WP_REST_Request $request The request object.
+ * @return WP_REST_Response The response object.
+ */
+function gocardless_e2e_update_access_token_callback( $request ) {
+	$access_token = $request->get_param( 'access_token' );
+	if ( empty( $access_token ) ) {
+		return new WP_REST_Response( array(
+			'error' => __( 'Access token is required.', 'gocardless-e2e' )
+		), 400 );
+	}
+
+	$settings = get_option( 'woocommerce_gocardless_settings', array() );
+	$settings['access_token'] = sanitize_text_field( $access_token );
+	update_option( 'woocommerce_gocardless_settings', $settings );
+
+	// Delete the available scheme transient, to request the available schemes again, to test the flow.
+	delete_transient( 'wc_gocardless_available_scheme_identifiers' );
+
+	return rest_ensure_response( array(
+		'success' => true,
+		'message' => __( 'Access token updated.', 'gocardless-e2e' ),
+	) );
+}

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -721,8 +721,7 @@ export async function validateGoCardlessPayment(page, orderId, isSub = false) {
 			.isVisible();
 		if (isSub && note) {
 			break;
-		} else if (!isSub && orderStatus === 'wc-processing') {
-			await page.waitForTimeout(10000);
+		} else if (!isSub && orderStatus === 'wc-processing' && note) {
 			break;
 		} else {
 			await page.waitForTimeout(10000); // wait for webhook to be processed

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -875,3 +875,41 @@ export async function clearCart(page) {
 		}
 	}
 }
+
+/**
+ * Updates the access token using the E2E test REST endpoint.
+ *
+ * Requires the `gocardless-e2e/v1/update-access-token` endpoint to be available.
+ *
+ * @param {import('@playwright/test').Page} page - The Playwright page object.
+ * @param {string} accessToken - The access token to update.
+ * @throws {Error} If the request fails or the response indicates an error.
+ */
+export async function updateAccessToken( page, accessToken ) {
+	const response = await page.request.post(
+		'/wp-json/gocardless-e2e/v1/update-access-token',
+		{
+			data: {
+				access_token: accessToken,
+			},
+			headers: {
+				'Content-Type': 'application/json',
+			},
+		}
+	);
+
+	if ( ! response.ok() ) {
+		const errorBody = await response.text();
+		throw new Error(
+			`Failed to update access token. HTTP ${ response.status() }: ${ errorBody }`
+		);
+	}
+
+	const result = await response.json();
+
+	if ( ! result.success ) {
+		throw new Error(
+			`Access token update failed: ${ result.error || 'Unknown error' }`
+		);
+	}
+}

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -550,6 +550,14 @@ export async function handleGoCardlessPaymentSchemeWise(
 		case 'bacs':
 		case 'becs':
 		case 'autogiro':
+			if (scheme === 'bacs') {
+				await page.waitForTimeout(3000);
+				if ( await page.getByTestId('checkout-as-guest').isVisible() ) {
+					await page
+						.getByTestId('checkout-as-guest')
+						.click({ force: true });
+				}
+			}
 			await page.getByTestId('branch_code').fill(data.bankCode);
 			await page
 				.getByTestId('account_number')

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -155,6 +155,7 @@ export async function blockFillBillingDetails(page, customerDetails) {
 		await page
 			.locator('select#billing-state')
 			.selectOption(customerDetails.state);
+		await page.locator('select#billing-state').blur();
 	}
 }
 
@@ -408,6 +409,13 @@ export async function handleGoCardlessPayment(page, options) {
 	await page
 		.getByRole('button', { name: 'Continue' })
 		.click({ force: true });
+
+	await page.waitForTimeout(3000);
+	if ( await page.getByTestId('checkout-as-guest').isVisible() ) {
+		await page
+			.getByTestId('checkout-as-guest')
+			.click({ force: true });
+	}
 
 	// Fill bank details
 	if (currency === 'USD') {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #92, if the GoCardless access token becomes invalid or inactive, there is currently no mechanism to disconnect the GoCardless account or make the gateway unavailable to prevent order placement failures. This results in orders failing with the error described in the issue. Additionally, due to the failed API responses, the “get available schemes (/creditors)” API response is not cached, causing repeated 401 calls for it.

This PR introduces changes to automatically disconnect the GoCardless account and display a notice prompting the admin to reconnect the account when the token becomes invalid or inactive (technically, when the API responds with a 401). This ensures that the GoCardless payment method is no longer visible at checkout and that no unnecessary calls to the creditors API are made. An admin notice will clearly inform the site owner to reconnect the account in order to restore the payment gateway functionality.

<img width="1995" height="225" alt="image" src="https://github.com/user-attachments/assets/a23b2276-b908-45ba-b910-2365ed02b869" />

> [!NOTE]
> In addition to showing a notice in the admin, we could also send an email to the site admin to reconnect the account. However, for now, showing the notice in the admin should be sufficient. If we receive requests from merchants, we can add the email notification later.

Closes #92

### Steps to test the changes in this Pull Request:
1. Connect a GoCardless account on one site.
2. Verify that it works as expected.
3. Connect the same GoCardless account on a different site (this will invalidate the token on the first site).
4. On the first site, attempt to place an order. Notice that the order fails due to a token error.
5. Refresh the page and confirm that the GoCardless payment gateway is no longer available.
6. In wp-admin, verify that a notice is displayed prompting you to reconnect the GoCardless account.
7. Go to the GoCardless payment method settings page, enable logging, and refresh the settings page multiple times.
8. Go to `WooCommerce > Status > Logs`, open the GoCardless logs, and confirm that there are no repeated `/creditors` API calls with 401 failures.
9. Reconnect the GoCardless account and confirm that everything works as expected.

### Changelog entry
> Fix - Automatically disconnect the GoCardless account and display a reconnect notice when the token becomes invalid or inactive.