### PR TITLE
Ensure our final release doesn't contain itself

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@fix/double-release-zip
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
 
   e2e:
     needs: build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@fix/double-release-zip
 
   e2e:
     needs: build
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - name: Download build zip
         uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
         with:

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm ci --no-optional
 
       - name: Build plugin
-        run: npm run build
+        run: npm run build:webpack
 
       - name: Generate ZIP file
         uses: 10up/action-wordpress-plugin-build-zip@b9e621e1261ccf51592b6f3943e4dc4518fca0d1 # v1.0.2

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   build:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"
-    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@fix/double-release-zip
 
   test:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   build:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"
-    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@fix/double-release-zip
+    uses: gocardless/woocommerce-gateway-gocardless/.github/workflows/generate-zip.yml@develop
 
   test:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.2
         with:
           name: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}
 
       - name: Build plugin zip
         run: zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #68 we changed the way we build our release zip. In testing out the final release zip prior to doing an actual release today, ran into an issue where I found that final release contained itself and was causing issues when trying to activate the plugin in WordPress.

Looking closer at the changes we made in #68, we run `npm run build` which will build the plugin and then run our archive command. We then run the `10up/action-wordpress-plugin-build-zip` workflow which will also produce a zip. This results with a zip within a zip, which causes problems.

This PR attempts to fix that by switching to `npm run build:webpack` which will just run our build steps not the archive steps.

### Steps to test the changes in this Pull Request:

Ensure the QIT build step and E2E build step pass, as both use the Generate Zip action.

### Changelog entry

n/a